### PR TITLE
Remove product update quantity jr

### DIFF
--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -59,8 +59,8 @@ module.exports.removeUserProduct = user_id => {
 									});
 							} else if (data.sold > 0) {
 								// TODO - change original quantity to # sold? (available)
-								// change original_quantity to sold_quantity (remove open order ordersProducts rows)
-								// remove from all open orders
+								// change original_quantity to sold_quantity
+								// remove from all open orders (remove open order ordersProducts rows)
 								// resolve (`${blue(`\n Removed product ${} from open orders, available quantity to zero`)}`);
 								resolve(`${red(`\n >>Cannot remove product id #${productId}, it is associated with orders<<`)}`);
 							} else {

--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -70,7 +70,7 @@ module.exports.removeUserProduct = user_id => {
 									.then(OPdata => {
 										console.log(OPdata);
 									})
-									.catch(() => {
+									.catch(err => {
 										return reject(err);
 									});
 								// resolve (`${blue(`\n Removed product ${} from open orders, available quantity to zero`)}`);

--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -7,6 +7,12 @@ const { red, blue } = require('chalk');
 let { dbCheckForProductSales, dbDeleteProduct, dbGetAllProductsByUser } = require('../models/Product.js');
 let { dbDeleteOpenOrderByProduct } = require('../models/Order-Product.js');
 
+/**
+ * Updates the current order with the user's selected payment type. This action completes the order.
+ * @param {number} - order ID from order table representing current active user's open order
+ * @param {object} - object containing key/value to be updated in the order object
+ * @return {promise} - resolves with a message that the order has been successfully updated
+ */
 module.exports.removeUserProduct = user_id => {
 	return new Promise((resolve, reject) => {
 		dbGetAllProductsByUser(user_id).then(data => {
@@ -42,7 +48,7 @@ module.exports.removeUserProduct = user_id => {
 									.then(() => {
 										dbDeleteOpenOrderByProduct(productId)
 											.then(() => {
-												resolve(`${blue(`\n Product id ${productId} removed`)}`);
+												resolve(`${blue(`\n Product id ${productId} removed from database`)}`);
 											})
 											.catch(err => {
 												return reject(err);
@@ -58,7 +64,7 @@ module.exports.removeUserProduct = user_id => {
 								// resolve (`${blue(`\n Removed product ${} from open orders, available quantity to zero`)}`);
 								resolve(`${red(`\n >>Cannot remove product id #${productId}, it is associated with orders<<`)}`);
 							} else {
-								resolve(`${red('\n >>Removing product unsuccessfull<<')}`);
+								return reject(`${red('\n >>Removing product unsuccessfull; database error, please contact admin<<')}`);
 							}
 						});
 					}

--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -33,8 +33,9 @@ module.exports.removeUserProduct = user_id => {
 						return reject(`${red(`\n  >>No product #${choice.number} listed<<`)}`);
 					} else {
 						let productId = productArr[choice.number - 1].id;
+						// this will change to dbGetSingleProduct
 						dbCheckForProductSales(productId).then(data => {
-							// if product has sold - reject (change to adjust quantity at some point)
+							// let data.sold ==> data.original_q - data.sold_quantity
 							if (data.sold === 0) {
 								// TODO add sold < original quantity case
 								dbDeleteProduct(productId)
@@ -44,7 +45,7 @@ module.exports.removeUserProduct = user_id => {
 												resolve(`${blue(`\n Product id ${productId} removed`)}`);
 											})
 											.catch(err => {
-												reject(err);
+												return reject(err);
 											});
 									})
 									.catch(err => {
@@ -52,7 +53,9 @@ module.exports.removeUserProduct = user_id => {
 									});
 							} else if (data.sold > 0) {
 								// TODO - change original quantity to # sold? (available)
-								// TODO - OR remove from all open orders, but do not delete product or closed orderProduct
+								// change original_quantity to sold_quantity (remove open order ordersProducts rows)
+								// remove from all open orders
+								// resolve (`${blue(`\n Removed product ${} from open orders, available quantity to zero`)}`);
 								resolve(`${red(`\n >>Cannot remove product id #${productId}, it is associated with orders<<`)}`);
 							} else {
 								resolve(`${red('\n >>Removing product unsuccessfull<<')}`);

--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -58,23 +58,25 @@ module.exports.removeUserProduct = user_id => {
 									});
 							} else if (data.sold > 0) {
 								let productUpdate = { original_quantity: data.sold };
+								console.log('productUpdate', productUpdate);
 								dbPutProduct(productUpdate, productId)
 									.then(updateData => {
-										console.log(updateData);
+										console.log('updateData', updateData);
+										// remove from all open orders (remove open order ordersProducts rows)
+										dbDeleteOpenOrderByProduct(productId)
+											.then(OPdata => {
+												console.log('OPdata', OPdata);
+												resolve(
+													`${blue(`\n >>Removed available quantity of #${productId} and removed from open orders<<`)}`
+												);
+											})
+											.catch(err => {
+												return reject(err);
+											});
 									})
 									.catch(err => {
 										return reject(err);
 									});
-								// remove from all open orders (remove open order ordersProducts rows)
-								dbDeleteOpenOrderByProduct(productId)
-									.then(OPdata => {
-										console.log(OPdata);
-									})
-									.catch(err => {
-										return reject(err);
-									});
-								// resolve (`${blue(`\n Removed product ${} from open orders, available quantity to zero`)}`);
-								resolve(`${red(`\n >>Cannot remove product id #${productId}, it is associated with orders<<`)}`);
 							} else {
 								return reject(`${red('\n >>Removing product unsuccessfull; database error, please contact admin<<')}`);
 							}

--- a/app/controllers/remove-user-product-ctrl.js
+++ b/app/controllers/remove-user-product-ctrl.js
@@ -8,10 +8,10 @@ let { dbCheckForProductSales, dbDeleteProduct, dbGetAllProductsByUser } = requir
 let { dbDeleteOpenOrderByProduct } = require('../models/Order-Product.js');
 
 /**
- * Updates the current order with the user's selected payment type. This action completes the order.
- * @param {number} - order ID from order table representing current active user's open order
- * @param {object} - object containing key/value to be updated in the order object
- * @return {promise} - resolves with a message that the order has been successfully updated
+ * Removes a users product from database, or if there are closed orders with product, set original_quantity to # sold (available = 0).
+ * @param {user_id} - order ID from order table representing current active user's open order
+ * @param {productId} - selected from prompt choice.number inside function: the id of product to remove
+ * @return {promise} - resolves with a message that the product has been successfully updated, or rejects with error
  */
 module.exports.removeUserProduct = user_id => {
 	return new Promise((resolve, reject) => {

--- a/app/models/Order-Product.js
+++ b/app/models/Order-Product.js
@@ -83,7 +83,7 @@ module.exports.dbDeleteOpenOrderByProduct = product_id => {
       AND o.payment_type_id = 'null')`,
 			function(err) {
 				if (err) return reject(err);
-				resolve({ message: 'delete successful', rows_deleted: this.changes });
+				resolve({ message: 'removed product from open orders', rows_deleted: this.changes });
 			}
 		);
 	});

--- a/app/models/Product.js
+++ b/app/models/Product.js
@@ -26,6 +26,20 @@ module.exports.dbGetSingleProduct = id => {
 	});
 };
 
+module.exports.dbGetSingleProductWithDetails = id => {
+	// TODO check that there is still inventory available
+	return new Promise((resolve, reject) => {
+		db.get(
+			`SELECT * FROM products
+            WHERE id = ${id}`,
+			(err, productdata) => {
+				if (err) return reject(err);
+				resolve(productdata);
+			}
+		);
+	});
+};
+
 module.exports.dbPostProduct = newProduct => {
 	return new Promise((resolve, reject) => {
 		let { product_type_id, price, title, description, original_quantity, seller_user_id } = newProduct;
@@ -49,13 +63,12 @@ module.exports.dbDeleteProduct = id => {
 	});
 };
 
-module.exports.dbPutProduct = (req, product_id) => {
-	let product = req.body;
+module.exports.dbPutProduct = (productObj, product_id) => {
 	return new Promise((resolve, reject) => {
 		let query = `UPDATE products SET `;
-		let keys = Object.keys(product);
+		let keys = Object.keys(productObj);
 		keys.forEach(key => {
-			query += `"${key}" = "${product[key]}",`;
+			query += `"${key}" = "${productObj[key]}",`;
 		});
 		query = query.slice(0, -1);
 		query += ` WHERE id = ${product_id}`;

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -88,7 +88,6 @@ module.exports.dbSellerRevenue = user_id => {
 			GROUP BY o.id, p.id`,
 			(err, revenueData) => {
 				if (err) return reject(err);
-				console.log(revenueData);
 				resolve(revenueData);
 			}
 		);


### PR DESCRIPTION
Related Issue:
#7 
Description:
Modified product removal to reset the original quantity of a product to the number sold, so that there are none available for sale, but purchase history is preserved.
Product is also removed from any open orders (/shopping carts).

Notes for Readme Info:

Chai/Mocha Tests added:
-relies on prompt input, hard to write tests!
-remove-user-product.test.js

Any other PR Testing Steps:
choose a customer(2)
choose remove product(7)
choose list number.

if you want to check in DB browser, make note of product id (in parentheses in list).  Here are queries:

# Sold and original_quantity by product ID:
SELECT count(op.product_id) as sold, p.original_quantity
FROM products p, orders o, ordersProducts op
WHERE  p.id = PRODUCTID
AND p.id = op.product_id
AND op.order_id = o.id
AND o.payment_type_id != 'null'

Product Info
SELECT * FROM products
WHERE id = PRODUCTID

Open orders
SELECT * FROM ordersProducts
WHERE exists
(SELECT *
FROM products p, orders o
WHERE p.id = PRODUCTID
AND p.id = ordersProducts.product_id
AND ordersProducts.order_id = o.id
AND o.payment_type_id = 'null')



